### PR TITLE
Localize page footer and add content classname

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -9,3 +9,9 @@ other = "Enter your message"
 
 [sendLabel]
 other = "Send"
+
+[published]
+other = "Published:"
+
+[updated]
+other = "Updated:"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
 						{{ with .Params.images }}
 							<span class="image featured"><img src="{{ index . 0 | absURL }}" alt=""></span>
 						{{ end }}
-						{{ .Content }}
+						<div class="page-content">{{ .Content }}</div>
 						{{ if or .Params.tags .Params.date }}
 							<hr />
 							<div id="meta">
@@ -24,8 +24,8 @@
 									{{ end }} {{/* range */}}
 							  </p>
 							{{ end }} {{/* if tags */}}
-							{{ with .Params.date }}<p class="meta">Published: {{ . | dateFormat "January 2, 2006"}}</p>{{ end }}
-							{{ with .Params.lastmod }}<p class="meta">Updated: {{ . | dateFormat "January 2, 2006"}}</p>{{ end }}
+							{{ with .Params.date }}<p class="meta">{{ i18n "published" }} {{ . | dateFormat "January 2, 2006"}}</p>{{ end }}
+							{{ with .Params.lastmod }}<p class="meta">{{ i18n "updated" }} {{ . | dateFormat "January 2, 2006"}}</p>{{ end }}
 							</div>
 						{{ end }} {{/* if meta */}}
 					</div>


### PR DESCRIPTION
Hi @funkydan2 :)
Just contributing to the localization file you started with the contact page.
I'm adding the "Published" and "Updated" strings from the page footer.

And I'm introducing a div with a specific classname around the pages content, allowing to add specific styles for the page content (for example for typography, table of content, etc.).

I initially only added this in my fork but I realized it could make sense to have it upstream. If not, no worries, I won't be upset 😄 