### PR TITLE
Change title link to BaseURL

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 <body {{ if .IsHome }} class="landing" {{ end }} >
   <div id="page-wrapper">
     <header id="header" {{ if .IsHome }} class="alt" {{ end }} >
-      <h1><a href="/">{{ .Site.Params.title }}</a></h1>
+      <h1><a href="{{ .Site.BaseURL }}">{{ .Site.Params.title }}</a></h1>
 
       {{ "<!-- Nav -->" | safeHTML }}
       <nav id="nav">


### PR DESCRIPTION
If a site is deployed at https://example.com/blog instead of https://example.com, it makes more sense to link to `.Site.BaseURL` instead of `/`. Please consider this PR. Thanks!