### PR TITLE
Make call for action optional

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -68,6 +68,7 @@
     button_text="Join a group today!"
 
 [CTA]
+  enable = true
   heading = "Get in touch!"
   message = "We'd love to hear from you."
 +++

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -72,6 +72,7 @@
 
 				</section>
 
+			{{ if .Params.CTA.enable }}
 			{{ "<!-- CTA -->" | safeHTML }}
 				<section id="cta"><a name="call-to-action"></a>
 
@@ -80,5 +81,6 @@
 					{{ partial "contact" .}}
 
 				</section>
+			{{ end }} {{/* end if CTA*/}}
 {{ partialCached "footer" . }}
 {{ partial "scripts" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -76,8 +76,8 @@
 			{{ "<!-- CTA -->" | safeHTML }}
 				<section id="cta"><a name="call-to-action"></a>
 
-					<h2>{{ .Params.CTA.heading}}</h2>
-					<p>{{ .Params.CTA.message}}</p>
+					{{ if .Params.CTA.heading }}<h2>{{ .Params.CTA.heading }}</h2>{{ end }}
+					{{ if .Params.CTA.message }}<p>{{ .Params.CTA.message }}</p>{{ end }}
 					{{ partial "contact" .}}
 
 				</section>


### PR DESCRIPTION
Allow users to enable contact form on the front page if needed. By default, it's disabled (BREAKING CHANGE) but the exampleSite index layout has been updated to enable the CTA by configuration.

Also, generate heading title and message paragraph only if they are configured. This avoids empty space in the CTA.