### PR TITLE
Simple shortcodes

### DIFF
--- a/exampleSite/content/kids.md
+++ b/exampleSite/content/kids.md
@@ -20,7 +20,6 @@ Here is some more text
 
 This is an example of multiple columns.
 
-Unfortunately it needs the author to write html to work (though I could put everything in the front matter!)
 
 {{< columns >}}
 

--- a/exampleSite/content/kids.md
+++ b/exampleSite/content/kids.md
@@ -22,14 +22,29 @@ This is an example of multiple columns.
 
 Unfortunately it needs the author to write html to work (though I could put everything in the front matter!)
 
+{{< columns >}}
 
-<div class="row">
-  <div class="col-6 col-12-mobilep">
-    <h3>Left Column</h3>
-    <p>You can fill this in with <i>html</i> or *markdown* </p>
-  </div>
-  <div class="col-6 col-12-mobilep">
-    <h3>And another subheading</h3>
-    <p>Adipiscing faucibus nunc placerat. Tempus adipiscing turpis non blandit accumsan eget lacinia nunc integer interdum amet aliquam ut orci non col ut ut praesent. Semper amet interdum mi. Phasellus enim laoreet ac ac commodo faucibus faucibus. Curae lorem ipsum adipiscing ac. Vivamus ornare laoreet odio vis praesent.</p>
-  </div>
-</div>
+### Left Column
+
+You can fill this in with *markdown*
+
+<--->
+
+### Another subheading
+
+Adipiscing faucibus nunc placerat. Tempus adipiscing turpis non blandit accumsan
+eget lacinia nunc integer interdum amet aliquam ut orci non col ut ut praesent.
+Semper amet interdum mi. Phasellus enim laoreet ac ac commodo faucibus faucibus.
+Curae lorem ipsum adipiscing ac. Vivamus ornare laoreet odio vis praesent.
+
+<--->
+
+### Another subheading
+
+Adipiscing faucibus nunc placerat. Tempus adipiscing turpis non blandit accumsan
+eget lacinia nunc integer interdum amet aliquam ut orci non col ut ut praesent.
+Semper amet interdum mi. Phasellus enim laoreet ac ac commodo faucibus faucibus.
+Curae lorem ipsum adipiscing ac. Vivamus ornare laoreet odio vis praesent.
+
+{{< /columns >}}
+

--- a/exampleSite/content/kids.md
+++ b/exampleSite/content/kids.md
@@ -6,9 +6,23 @@ images: [img/freely-10057.jpg]
 tags: ["two_column","ministry"]
 draft: false
 ---
+
+## Section
+
+Here is some text
+
+{{< seperator >}}
+
+
+## Another Section
+
+Here is some more text
+
 This is an example of multiple columns.
 
 Unfortunately it needs the author to write html to work (though I could put everything in the front matter!)
+
+
 <div class="row">
   <div class="col-6 col-12-mobilep">
     <h3>Left Column</h3>

--- a/exampleSite/content/leaders.md
+++ b/exampleSite/content/leaders.md
@@ -6,3 +6,9 @@ draft: false
 # This is a page about leaders
 
 ![This is an image](/img/freely-26905.jpg)
+
+{{< button >}}
+
+{{< button text="hi" >}}
+
+{{< button class="alt" link="https://example.com" >}}

--- a/layouts/_shortcodes/button.html
+++ b/layouts/_shortcodes/button.html
@@ -1,0 +1,28 @@
+{{/*
+	This shortcode will insert an anchor (link) with the class of button
+
+	There are no "required" fields, but you probably want to use "link" and "text"
+
+	You can also give an argument "class" which will be appended to the anchors class list
+
+	Useful for "alt" or "fit" which are both provided by the alfa theme
+
+	# Examples
+
+
+	{{< button link="https://example.com" text="Find out more" >}}
+
+*/}}
+{{- $classes := printf "button %s" (.Get "class") -}}
+{{- $text := "Find out more" -}}
+{{- if .Get "text" -}}
+{{- $text = .Get "text" -}}
+{{- end -}}
+{{- $link := "/" -}}
+{{- if .Get "link" -}}
+{{- $link = .Get "link" -}}
+{{- end -}}
+
+
+<a href="{{ $link }}" class="{{ $classes }}">{{ $text }}</a>
+

--- a/layouts/_shortcodes/columns.html
+++ b/layouts/_shortcodes/columns.html
@@ -1,0 +1,33 @@
+{{/*
+	This shortcode allows you to write in columns
+
+	Collumns are deliminated by <--->
+
+	# Examples
+
+	{{< columns >}}
+
+	## columnn 1
+
+	<--->
+
+	## column 2
+
+	{{< /columns >}}
+*/}}
+{{- $cols := split .InnerDeindent "<--->" -}}
+{{- $width := div 12 ( $cols | len ) -}}
+{{- $mobWidth := 12 -}}
+{{- if lt $width 6 -}}
+{{- $mobWidth = 6 -}}
+{{- end -}}
+
+
+
+<div class="row">
+{{ range $index, $content := split .InnerDeindent "<--->" }}
+	<div class="col-{{ $width }} col-{{ $mobWidth }}-mobilep">
+    {{ $content | page.RenderString }}
+	</div>
+{{ end }}
+</div>

--- a/layouts/_shortcodes/seperator.html
+++ b/layouts/_shortcodes/seperator.html
@@ -1,0 +1,36 @@
+{{/*
+	This shortcode adds a seperator between sections of a page
+
+	It will essentially close off the precceding "box" and start a new one when
+	used in its most simple form
+
+	It also accepts start=true or end=true. These are to be used when you don't
+	want to start a new box or end an existing box (perhaps after a feature row)
+
+	# Examples
+
+	## Normal seperator
+
+	This will close the old box and start a new one
+
+	{{< seperator >}}
+
+	## End seperator
+
+	This will close the old box but will not start a new one
+
+	{{< seperator end=true >}}
+
+	## Start seperator
+
+	This will start a new box but will not end the old one
+
+	{{< seperator start=true >}}
+*/}}
+{{- if and (not (.Get "start")) (ne (.Get "start") true) -}}
+</div></div>
+{{- end -}}
+{{- if and (not (.Get "end")) (ne (.Get "end") true) -}}
+<div class="box">
+	<div class="page-content">
+{{- end -}}


### PR DESCRIPTION
This pull request adds a `{{ seperator }}` shortcode and a `{{ columns }}` short code. Both are demonstrated on the kids page of the example site and documented somewhat in the comment at the top of the shortcode file.

