### PR TITLE
Fixes Nav markup

### DIFF
--- a/layouts/_partials/nav.html
+++ b/layouts/_partials/nav.html
@@ -23,10 +23,10 @@
                                 <li><a href="{{ .URL |relURL }}">{{ .Name }}</a></li>
                               {{ end }}
                               </ul>
+                            </li>
                           {{ else }}
                             <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
                           {{ end }}
-                          </li>
                       {{ end }}
                     </ul>
                   </li>


### PR DESCRIPTION
An extra closing li was being added when sub pages exist